### PR TITLE
Ensure "start" script works in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "concurrently 'eleventy --watch --incremental' 'vite _site'"
+    "start": "concurrently \"eleventy --watch --incremental\" \"vite _site\""
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Sorry to bug. Another minor thing that relates to #1, but I saw #2 was merged so quickly and the only other issue with this was launching it in windows. Just a minor case of swapping out the single quotes with double quotes. 🙂

Otherwise, you get this lovely error:

![image](https://user-images.githubusercontent.com/4269377/158475090-a26a052d-40f2-4f73-8039-680dfc566f1b.png)
